### PR TITLE
Añadida directiva run-local para ejecución sin Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,6 @@
 
 run:
 	docker run --rm --volume `pwd`:/opt/app --env PYTHON_PATH=/opt/app -w /opt/app python:3.6-slim python3 main.py words.txt yes
+
+run-local:
+	python3 main.py words.txt yes


### PR DESCRIPTION
Añadir una directiva en el Makefile que ejecute el comando en local, sin arrancar un contenedor de Docker.